### PR TITLE
Enable hierarchy UI feature in visualizer for SemanticKITTI

### DIFF
--- a/ml3d/datasets/semantickitti.py
+++ b/ml3d/datasets/semantickitti.py
@@ -125,7 +125,7 @@ class SemanticKITTI(BaseDataset):
     def is_tested(self, attr):
         cfg = self.cfg
         name = attr['name']
-        name_seq, name_points = name.split("_")
+        name_seq, name_points = name.split("/")
         test_path = join(cfg.test_result_folder, 'sequences')
         save_path = join(test_path, name_seq, 'predictions')
         test_file_name = name_points
@@ -139,7 +139,7 @@ class SemanticKITTI(BaseDataset):
     def save_test_result(self, results, attr):
         cfg = self.cfg
         name = attr['name']
-        name_seq, name_points = name.split("_")
+        name_seq, name_points = name.split("/")
 
         test_path = join(cfg.test_result_folder, 'sequences')
         make_dir(test_path)
@@ -159,7 +159,7 @@ class SemanticKITTI(BaseDataset):
         cfg = self.cfg
         for j in range(1):
             name = inputs['attr']['name']
-            name_seq, name_points = name.split("_")
+            name_seq, name_points = name.split("/")
 
             test_path = join(cfg.test_result_folder, 'sequences')
             make_dir(test_path)
@@ -251,7 +251,7 @@ class SemanticKITTISplit():
         pc_path = self.path_list[idx]
         dir, file = split(pc_path)
         _, seq = split(split(dir)[0])
-        name = '{}_{}'.format(seq, file[:-4])
+        name = '{}/{}'.format(seq, file[:-4])
 
         attr = {'name': name, 'path': pc_path, 'split': self.split}
         return attr

--- a/ml3d/datasets/semantickitti.py
+++ b/ml3d/datasets/semantickitti.py
@@ -125,7 +125,7 @@ class SemanticKITTI(BaseDataset):
     def is_tested(self, attr):
         cfg = self.cfg
         name = attr['name']
-        name_seq, name_points = name.split("/")
+        name_seq, name_points = name.split("_")
         test_path = join(cfg.test_result_folder, 'sequences')
         save_path = join(test_path, name_seq, 'predictions')
         test_file_name = name_points
@@ -139,7 +139,7 @@ class SemanticKITTI(BaseDataset):
     def save_test_result(self, results, attr):
         cfg = self.cfg
         name = attr['name']
-        name_seq, name_points = name.split("/")
+        name_seq, name_points = name.split("_")
 
         test_path = join(cfg.test_result_folder, 'sequences')
         make_dir(test_path)
@@ -159,7 +159,7 @@ class SemanticKITTI(BaseDataset):
         cfg = self.cfg
         for j in range(1):
             name = inputs['attr']['name']
-            name_seq, name_points = name.split("/")
+            name_seq, name_points = name.split("_")
 
             test_path = join(cfg.test_result_folder, 'sequences')
             make_dir(test_path)
@@ -251,7 +251,7 @@ class SemanticKITTISplit():
         pc_path = self.path_list[idx]
         dir, file = split(pc_path)
         _, seq = split(split(dir)[0])
-        name = '{}/{}'.format(seq, file[:-4])
+        name = '{}_{}'.format(seq, file[:-4])
 
         attr = {'name': name, 'path': pc_path, 'split': self.split}
         return attr

--- a/ml3d/vis/visualizer.py
+++ b/ml3d/vis/visualizer.py
@@ -219,9 +219,20 @@ class DatasetModel(Model):
             real_indices = [path2idx[p] for p in sorted(path2idx.keys())]
             indices = [real_indices[idx] for idx in indices]
 
+            # SemanticKITTI names its items <sequence#>_<timeslice#>,
+            # "mm_nnnnnn". We'd like to use the hierarchical feature of the tree
+            # to separate the sequences. We cannot change the name in the dataset
+            # because this format is used to report algorithm results, so do it
+            # here.
+            underscore_to_slash = False
+            if dataset.__class__.__name__ == "SemanticKITTI":
+                underscore_to_slash = True
+
             for i in indices:
                 info = self._dataset.get_attr(i)
                 name = info["name"]
+                if underscore_to_slash:
+                    name = name.replace("_", "/")
                 while name in self._data:  # ensure each name is unique
                     name = name + "_"
 


### PR DESCRIPTION
The visualizer will split up names into a hierarchy based on "/" in their names. This PR changes the name of SemanticKITTI items from `mm_nnnnnn` to `mm/nnnnn` to take advantage of that. This makes the 20000 items in SemanticKITTI a lot easier to navigate, and it allows one to select all the items in one sequence by clicking on the sequence parent, not all 2000 individual items. Needless to say, this makes animating a sequence much easier!

<img width="343" alt="image" src="https://user-images.githubusercontent.com/2333353/96929821-a5c4de00-146f-11eb-8248-f543268ed386.png">
