### PR TITLE
Add bounding boxes to visualizer

### DIFF
--- a/ml3d/vis/__init__.py
+++ b/ml3d/vis/__init__.py
@@ -1,4 +1,5 @@
 """Visualizer for 3D ML"""
 
+from .boundingbox import *
 from .colormap import *
 from .visualizer import *

--- a/ml3d/vis/boundingbox.py
+++ b/ml3d/vis/boundingbox.py
@@ -1,16 +1,29 @@
 import numpy as np
 import open3d as o3d
 
+
 class BoundingBox3D:
     next_id = 1
-    def __init__(self, center, front, up, left, size, label_class, confidence,
-                 meta=None, show_class=False, show_confidence=False,
-                 show_meta=None, identifier=None, arrow_length=1.0):
-        assert(len(center) == 3)
-        assert(len(front) == 3)
-        assert(len(up) == 3)
-        assert(len(left) == 3)
-        assert(len(size) == 3)
+
+    def __init__(self,
+                 center,
+                 front,
+                 up,
+                 left,
+                 size,
+                 label_class,
+                 confidence,
+                 meta=None,
+                 show_class=False,
+                 show_confidence=False,
+                 show_meta=None,
+                 identifier=None,
+                 arrow_length=1.0):
+        assert (len(center) == 3)
+        assert (len(front) == 3)
+        assert (len(up) == 3)
+        assert (len(left) == 3)
+        assert (len(size) == 3)
 
         self.center = np.array(center, dtype="float32")
         self.front = np.array(front, dtype="float32")
@@ -31,7 +44,8 @@ class BoundingBox3D:
         self.arrow_length = arrow_length
 
     def __repr__(self):
-        s = str(self.identifier) + " (class=" + str(self.label_class) + ", conf=" + str(self.confidence)
+        s = str(self.identifier) + " (class=" + str(
+            self.label_class) + ", conf=" + str(self.confidence)
         if self.meta is not None:
             s = s + ", meta=" + str(self.meta)
         s = s + ")"
@@ -56,7 +70,7 @@ class BoundingBox3D:
             head_length = 0.3 * box.arrow_length
             # It seems to be substantially faster to assign directly for the
             # points, as opposed to points[pidx:pidx+nverts] = np.stack((...))
-            points[pidx    ] = box.center + x + y + z
+            points[pidx] = box.center + x + y + z
             points[pidx + 1] = box.center - x + y + z
             points[pidx + 2] = box.center - x + y - z
             points[pidx + 3] = box.center + x + y - z
@@ -76,23 +90,17 @@ class BoundingBox3D:
             box = boxes[i]
             pidx = nverts * i
             idx = nlines * i
-            indices[idx:idx+nlines] = ((pidx,     pidx + 1),
-                                       (pidx + 1, pidx + 2),
-                                       (pidx + 2, pidx + 3),
-                                       (pidx + 3, pidx),
-                                       (pidx + 4, pidx + 5),
-                                       (pidx + 5, pidx + 6),
-                                       (pidx + 6, pidx + 7),
-                                       (pidx + 7, pidx + 4),
-                                       (pidx + 0, pidx + 4),
-                                       (pidx + 1, pidx + 5),
-                                       (pidx + 2, pidx + 6),
-                                       (pidx + 3, pidx + 7),
-                                       (pidx + 8, pidx + 9),
-                                       (pidx + 9, pidx + 10),
-                                       (pidx + 9, pidx + 11),
-                                       (pidx + 9, pidx + 12),
-                                       (pidx + 9, pidx + 13))
+            indices[idx:idx +
+                    nlines] = ((pidx, pidx + 1), (pidx + 1, pidx + 2),
+                               (pidx + 2, pidx + 3), (pidx + 3, pidx),
+                               (pidx + 4, pidx + 5), (pidx + 5, pidx + 6),
+                               (pidx + 6, pidx + 7), (pidx + 7, pidx + 4),
+                               (pidx + 0, pidx + 4), (pidx + 1, pidx + 5),
+                               (pidx + 2, pidx + 6), (pidx + 3, pidx + 7),
+                               (pidx + 8, pidx + 9), (pidx + 9, pidx + 10),
+                               (pidx + 9, pidx + 11), (pidx + 9,
+                                                       pidx + 12), (pidx + 9,
+                                                                    pidx + 13))
 
             if lut is not None:
                 label = lut.labels[box.label_class]
@@ -100,7 +108,8 @@ class BoundingBox3D:
             else:
                 c = (0.5, 0.5, 0.5)
 
-            colors[idx:idx+nlines] = c  # copies c to each element in the range
+            colors[idx:idx +
+                   nlines] = c  # copies c to each element in the range
 
         lines = o3d.geometry.LineSet()
         lines.points = o3d.utility.Vector3dVector(points)

--- a/ml3d/vis/boundingbox.py
+++ b/ml3d/vis/boundingbox.py
@@ -1,0 +1,110 @@
+import numpy as np
+import open3d as o3d
+
+class BoundingBox3D:
+    next_id = 1
+    def __init__(self, center, front, up, left, size, label_class, confidence,
+                 meta=None, show_class=False, show_confidence=False,
+                 show_meta=None, identifier=None, arrow_length=1.0):
+        assert(len(center) == 3)
+        assert(len(front) == 3)
+        assert(len(up) == 3)
+        assert(len(left) == 3)
+        assert(len(size) == 3)
+
+        self.center = np.array(center, dtype="float32")
+        self.front = np.array(front, dtype="float32")
+        self.up = np.array(up, dtype="float32")
+        self.left = np.array(left, dtype="float32")
+        self.size = size
+        self.label_class = label_class
+        self.confidence = confidence
+        self.meta = meta
+        self.show_class = show_class
+        self.show_confidence = show_confidence
+        self.show_meta = show_meta
+        if identifier is not None:
+            self.identifier = identifier
+        else:
+            self.identifier = "box:" + str(BoundingBox3D.next_id)
+            BoundingBox3D.next_id += 1
+        self.arrow_length = arrow_length
+
+    def __repr__(self):
+        s = str(self.identifier) + " (class=" + str(self.label_class) + ", conf=" + str(self.confidence)
+        if self.meta is not None:
+            s = s + ", meta=" + str(self.meta)
+        s = s + ")"
+        return s
+
+    @staticmethod
+    def create_lines(boxes, lut):
+        nverts = 14
+        nlines = 17
+        points = np.zeros((nverts * len(boxes), 3), dtype="float32")
+        indices = np.zeros((nlines * len(boxes), 2), dtype="int32")
+        colors = np.zeros((nlines * len(boxes), 3), dtype="float32")
+
+        for i in range(0, len(boxes)):
+            box = boxes[i]
+            pidx = nverts * i
+            x = box.size[0] * box.left
+            y = box.size[1] * box.up
+            z = box.size[2] * box.front
+            arrow_tip = box.center + z + box.arrow_length * box.front
+            arrow_mid = box.center + z + 0.60 * box.arrow_length * box.front
+            head_length = 0.3 * box.arrow_length
+            # It seems to be substantially faster to assign directly for the
+            # points, as opposed to points[pidx:pidx+nverts] = np.stack((...))
+            points[pidx    ] = box.center + x + y + z
+            points[pidx + 1] = box.center - x + y + z
+            points[pidx + 2] = box.center - x + y - z
+            points[pidx + 3] = box.center + x + y - z
+            points[pidx + 4] = box.center + x - y + z
+            points[pidx + 5] = box.center - x - y + z
+            points[pidx + 6] = box.center - x - y - z
+            points[pidx + 7] = box.center + x - y - z
+            points[pidx + 8] = box.center + z
+            points[pidx + 9] = arrow_tip
+            points[pidx + 10] = arrow_mid + head_length * box.up
+            points[pidx + 11] = arrow_mid - head_length * box.up
+            points[pidx + 12] = arrow_mid + head_length * box.left
+            points[pidx + 13] = arrow_mid - head_length * box.left
+
+        # It is faster to break the indices and colors into their own loop.
+        for i in range(0, len(boxes)):
+            box = boxes[i]
+            pidx = nverts * i
+            idx = nlines * i
+            indices[idx:idx+nlines] = ((pidx,     pidx + 1),
+                                       (pidx + 1, pidx + 2),
+                                       (pidx + 2, pidx + 3),
+                                       (pidx + 3, pidx),
+                                       (pidx + 4, pidx + 5),
+                                       (pidx + 5, pidx + 6),
+                                       (pidx + 6, pidx + 7),
+                                       (pidx + 7, pidx + 4),
+                                       (pidx + 0, pidx + 4),
+                                       (pidx + 1, pidx + 5),
+                                       (pidx + 2, pidx + 6),
+                                       (pidx + 3, pidx + 7),
+                                       (pidx + 8, pidx + 9),
+                                       (pidx + 9, pidx + 10),
+                                       (pidx + 9, pidx + 11),
+                                       (pidx + 9, pidx + 12),
+                                       (pidx + 9, pidx + 13))
+
+            if lut is not None:
+                label = lut.labels[box.label_class]
+                c = (label.color[0], label.color[1], label.color[2])
+            else:
+                c = (0.5, 0.5, 0.5)
+
+            colors[idx:idx+nlines] = c  # copies c to each element in the range
+
+        lines = o3d.geometry.LineSet()
+        lines.points = o3d.utility.Vector3dVector(points)
+        lines.lines = o3d.utility.Vector2iVector(indices)
+        lines.colors = o3d.utility.Vector3dVector(colors)
+
+        return lines

--- a/ml3d/vis/boundingbox.py
+++ b/ml3d/vis/boundingbox.py
@@ -3,6 +3,8 @@ import open3d as o3d
 
 
 class BoundingBox3D:
+    """Class that defines an axially-oriented bounding box."""
+
     next_id = 1
 
     def __init__(self,
@@ -19,6 +21,29 @@ class BoundingBox3D:
                  show_meta=None,
                  identifier=None,
                  arrow_length=1.0):
+        """Creates a bounding box. Front, up, left define the axis of the box
+        and must be normalized and mutually orthogonal.
+
+        center: (x, y, z) that defines the center of the box
+        front: normalized (i, j, k) that defines the front direction of the box
+        up: normalized (i, j, k) that defines the up direction of the box
+        left: normalized (i, j, k) that defines the left direction of the box
+        size: (width, height, depth) that defines the size of the box, as
+            measured from edge to edge
+        label_class: integer specifying the classification label. If an LUT is
+            specified in create_lines() this will be used to determine the color
+            of the box.
+        confidence: confidence level of the box
+        meta: a user-defined string (optional)
+        show_class: displays the class label in text near the box (optional)
+        show_confidence: displays the confidence value in text near the box
+            (optional)
+        show_meta: displays the meta string in text near the box (optional)
+        identifier: a unique integer that defines the id for the box (optional,
+            will be generated if not provided)
+        arrow_length: the length of the arrow in the front_direct. Set to zero
+            to disable the arrow (optional)
+        """
         assert (len(center) == 3)
         assert (len(front) == 3)
         assert (len(up) == 3)
@@ -52,7 +77,15 @@ class BoundingBox3D:
         return s
 
     @staticmethod
-    def create_lines(boxes, lut):
+    def create_lines(boxes, lut=None):
+        """Creates and returns an open3d.geometry.LineSet that can be used to
+        render the boxes.
+
+        boxes: the list of bounding boxes
+        lut: a ml3d.vis.LabelLUT that is used to look up the color based on the
+            label_class argument of the BoundingBox3D constructor. If not
+            provided, a color of 50% grey will be used. (optional)
+        """
         nverts = 14
         nlines = 17
         points = np.zeros((nverts * len(boxes), 3), dtype="float32")
@@ -62,9 +95,9 @@ class BoundingBox3D:
         for i in range(0, len(boxes)):
             box = boxes[i]
             pidx = nverts * i
-            x = box.size[0] * box.left
-            y = box.size[1] * box.up
-            z = box.size[2] * box.front
+            x = 0.5 * box.size[0] * box.left
+            y = 0.5 * box.size[1] * box.up
+            z = 0.5 * box.size[2] * box.front
             arrow_tip = box.center + z + box.arrow_length * box.front
             arrow_mid = box.center + z + 0.60 * box.arrow_length * box.front
             head_length = 0.3 * box.arrow_length

--- a/ml3d/vis/visualizer.py
+++ b/ml3d/vis/visualizer.py
@@ -1,9 +1,11 @@
+import math
 import numpy as np
 import threading
 import open3d as o3d
 from open3d.visualization import gui
 from open3d.visualization import rendering
 from collections import deque
+from .boundingbox import *
 from .colormap import *
 from .labellut import *
 
@@ -13,6 +15,13 @@ import time
 class Model:
     """Attributes, data, and methods of visulization models."""
 
+    bounding_box_prefix = "Bounding Boxes/"
+
+    class BoundingBoxData:
+        def __init__(self, name, boxes):
+            self.name = name
+            self.boxes = boxes
+
     def __init__(self):
         # Note: the tpointcloud cannot store the actual data arrays, because
         # the tpointcloud requires specific names for some arrays (e.g. "points",
@@ -20,6 +29,7 @@ class Model:
         # contains the "points" array.
         self.tclouds = {}  # name -> tpointcloud
         self.data_names = []  # the order data will be displayed / animated
+        self.bounding_box_data = []  # [BoundingBoxData]
 
         self._data = {}  # name -> {attr_name -> numpyarray}
         self._known_attrs = {}  # name -> set(attrs)
@@ -35,7 +45,12 @@ class Model:
         self.data_names.append(name)
 
     def is_loaded(self, name):
-        return len(self._data[name]) > 0
+        if name in self._data:
+            return len(self._data[name]) > 0
+        else:
+            # if the name isn't in the data, presumably it is loaded
+            # (for instance, if this is a bounding box).
+            return True
 
     def load(self, name, fail_if_no_space=False):
         assert (False)  # pure virtual
@@ -86,7 +101,10 @@ class Model:
 
     def _convert_to_numpy(self, ary):
         if isinstance(ary, list):
-            return np.array(ary, dtype='float32')
+            try:
+                return np.array(ary, dtype='float32')
+            except TypeError:
+                return None
         elif isinstance(ary, np.ndarray):
             if len(ary.shape) == 2 and ary.shape[0] == 1:
                 ary = ary[0]  # "1D" array as 2D: [[1, 2, 3,...]]
@@ -219,20 +237,9 @@ class DatasetModel(Model):
             real_indices = [path2idx[p] for p in sorted(path2idx.keys())]
             indices = [real_indices[idx] for idx in indices]
 
-            # SemanticKITTI names its items <sequence#>_<timeslice#>,
-            # "mm_nnnnnn". We'd like to use the hierarchical feature of the tree
-            # to separate the sequences. We cannot change the name in the dataset
-            # because this format is used to report algorithm results, so do it
-            # here.
-            underscore_to_slash = False
-            if dataset.__class__.__name__ == "SemanticKITTI":
-                underscore_to_slash = True
-
             for i in indices:
                 info = self._dataset.get_attr(i)
                 name = info["name"]
-                if underscore_to_slash:
-                    name = name.replace("_", "/")
                 while name in self._data:  # ensure each name is unique
                     name = name + "_"
 
@@ -249,7 +256,7 @@ class DatasetModel(Model):
 
     def is_loaded(self, name):
         loaded = super().is_loaded(name)
-        if loaded:
+        if loaded and name in self._cached_data:
             # make this point cloud the most recently used
             self._cached_data.remove(name)
             self._cached_data.append(name)
@@ -265,6 +272,9 @@ class DatasetModel(Model):
         data = self._dataset.get_data(idx)
         data["name"] = name
         data["points"] = data["point"]
+
+        if 'bounding_boxes' in data:
+            self.bounding_box_data.append(Model.BoundingBoxData(name, data['bounding_boxes']))
 
         self.create_point_cloud(data)
         size = self._calc_pointcloud_size(self._data[name], self.tclouds[name])
@@ -304,6 +314,12 @@ class DatasetModel(Model):
                                                o3d.core.Device("CPU:0"))
             self.tclouds[name] = tcloud
             self._data[name] = {}
+
+            bbox_name = Model.bounding_box_prefix + name
+            for i in range(0, len(self.bounding_box_data)):
+                if self.bounding_box_data[i].name == bbox_name:
+                    self.bounding_box_data.pop(i)
+                    break
 
 
 class Visualizer:
@@ -634,6 +650,7 @@ class Visualizer:
         self._animation_frames = []
         self._last_animation_time = time.time()
         self._animation_delay_secs = 0.100
+        self._consolidate_bounding_boxes = False
         self._dont_update_geometry = False
 
     def _init_dataset(self, dataset, split, indices):
@@ -837,6 +854,7 @@ class Visualizer:
         # Populate tree, etc.
         for name in self._objects.data_names:
             self._add_tree_name(name)
+
         self._update_datasource_combobox()
 
     def set_lut(self, attr_name, lut):
@@ -868,9 +886,10 @@ class Visualizer:
             if n.startswith(prefix):
                 self._3d.scene.show_geometry(n, show)
                 node.checkbox.checked = show
+        self._update_bounding_boxes()
         self._3d.force_redraw()
 
-    def _add_tree_name(self, name):
+    def _add_tree_name(self, name, is_geometry=True):
         names = name.split("/")
         parent = self._dataset.get_root_item()
         for i in range(0, len(names) - 1):
@@ -890,11 +909,15 @@ class Visualizer:
 
         def on_checked(checked):
             self._3d.scene.show_geometry(name, checked)
-            self._update_datasource_combobox()  # available attrs could change
+            if self._is_tree_name_geometry(name):
+                self._update_bounding_boxes()
+                # available attrs could change
+                self._update_datasource_combobox()
             self._3d.force_redraw()
 
         cell = gui.CheckableTextTreeCell(names[-1], True, on_checked)
-        cell.label.text_color = gui.Color(1.0, 0.0, 0.0, 1.0)
+        if is_geometry:
+            cell.label.text_color = gui.Color(1.0, 0.0, 0.0, 1.0)
         node = self._dataset.add_item(parent, cell)
         self._name2treenode[name] = cell
         self._treeid2name[node] = name
@@ -959,11 +982,12 @@ class Visualizer:
             if not tcloud.is_empty():
                 self._name2treenode[n].label.text_color = gui.Color(
                     0.0, 1.0, 0.0, 1.0)
+                if self._3d.scene.has_geometry(n):
+                    self._3d.scene.modify_geometry_material(n, material)
             else:
                 self._name2treenode[n].label.text_color = gui.Color(
                     1.0, 0.0, 0.0, 1.0)
                 self._name2treenode[n].checkbox.checked = False
-        self._3d.scene.update_material(material)
         self._3d.force_redraw()
 
     def _update_point_cloud(self, name, tcloud, material):
@@ -1030,6 +1054,51 @@ class Visualizer:
 
         return material
 
+    def _update_bounding_boxes(self):
+        if len(self._attrname2lut) == 1:
+            # Can't do dict.values()[0], so have to iterate over the 1 element
+            for v in self._attrname2lut.values():
+                lut = v
+        elif "labels" in self._attrname2lut:
+            lut = self._attrname2lut["labels"]
+        elif "label" in self._attrname2lut:
+            lut = self._attrname2lut["label"]
+        else:
+            lut = None
+
+        mat = rendering.Material()
+        mat.shader = "defaultUnlit"
+
+        if self._consolidate_bounding_boxes:
+            name = Model.bounding_box_prefix.split("/")[0]
+            boxes = []
+            for bbox_data in self._objects.bounding_box_data:
+                # When consolidated we assume bbox_data.name is the geometry
+                # name.
+                if bbox_data.name in self._name2treenode and self._name2treenode[bbox_data.name].checkbox.checked:
+                    boxes += bbox_data.boxes
+
+            self._3d.scene.remove_geometry(name)
+            if len(boxes) > 0:
+                lines = BoundingBox3D.create_lines(boxes, lut)
+                self._3d.scene.add_geometry(name, lines, mat)
+
+                if name not in self._name2treenode:
+                    self._add_tree_name(name, is_geometry=False)
+        else:
+            # Only run this once if we aren't consolidating, because nothing will
+            # change.
+            if len(self._objects.bounding_box_data) > 0:
+                if self._objects.bounding_box_data[0].name in self._name2treenode:
+                    return
+
+            for bbox_data in self._objects.bounding_box_data:
+                lines = BoundingBox3D.create_lines(bbox_data.boxes, lut)
+                self._3d.scene.add_geometry(bbox_data.name, lines, mat)
+
+            for bbox_data in self._objects.bounding_box_data:
+                self._add_tree_name(bbox_data.name, is_geometry=False)
+
     def _update_gradient(self):
         if self._shader.selected_text == self.LABELS_NAME:
             colors = self._label_edit.get_colors()
@@ -1059,7 +1128,9 @@ class Visualizer:
 
     def _update_geometry_colors(self):
         material = self._get_material()
-        self._3d.scene.update_material(material)
+        for name, tcloud in self._objects.tclouds.items():
+            if not tcloud.is_empty() and self._3d.scene.has_geometry(name):
+                    self._3d.scene.modify_geometry_material(name, material)
         self._3d.force_redraw()
 
     def _update_datasource_combobox(self):
@@ -1078,7 +1149,7 @@ class Visualizer:
             # 2) geometries are selected: color solid
             has_checked = False
             for n, node in self._name2treenode.items():
-                if node.checkbox.checked:
+                if node.checkbox.checked and self._is_tree_name_geometry(n):
                     has_checked = True
                     break
             if has_checked:
@@ -1162,6 +1233,8 @@ class Visualizer:
 
     def _on_dataset_selection_changed(self, item):
         name = self._treeid2name[item]
+        if not self._is_tree_name_geometry(name):
+            return
 
         def ui_callback():
             self._update_attr_range()
@@ -1281,15 +1354,21 @@ class Visualizer:
         self._update_geometry()
 
     def _get_selected_names(self):
+        # Note that things like bounding boxes could be in the tree, and we
+        # do not want to include them in the list of things selected, even if
+        # they are checked.
         selected_names = []
-        for n, node in self._name2treenode.items():
-            if node.checkbox.checked:
+        for n in self._objects.data_names:
+            if self._name2treenode[n].checkbox.checked:
                 selected_names.append(n)
         return selected_names
 
     def _get_available_attrs(self):
         selected_names = self._get_selected_names()
         return self._objects.get_available_attrs(selected_names)
+
+    def _is_tree_name_geometry(self, name):
+        return (name in self._objects.data_names)
 
     @staticmethod
     def _make_tcloud_array(np_array, copy=False):
@@ -1329,10 +1408,12 @@ class Visualizer:
             lut.add_label(dataset.label_to_names[val], val)
         self.set_lut("labels", lut)
 
+        self._consolidate_bounding_boxes = True
         self._init_dataset(dataset, split, indices)
         self._visualize("Open3D - " + dataset.name, width, height)
-
-    def visualize(self, data, width=1024, height=768):
+ 
+    def visualize(self, data, lut=None, bounding_boxes=None,
+                  width=1024, height=768):
         """Visualizes custom point cloud data
 
         Example:
@@ -1360,6 +1441,38 @@ class Visualizer:
             height: window height.
         """
         self._init_data(data)
+
+        if lut is not None:
+            self.set_lut("labels", lut)
+
+        if bounding_boxes is not None:
+            prefix = Model.bounding_box_prefix
+            # Filament crashes if you have to many items, and anyway, hundreds
+            # of items is unweildy in a list. So combine items if we have too
+            # many.
+            group_size = int(math.floor(float(len(bounding_boxes)) / 100.0))
+            if group_size < 2:
+                box_data = [Model.BoundingBoxData(prefix + str(bbox), [bbox])
+                            for bbox in bounding_boxes]
+            else:
+                box_data = []
+                current_group = []
+                n = len(bounding_boxes)
+                for i in range(0, n):
+                    current_group.append(bounding_boxes[i])
+                    if len(current_group) >= group_size or i == n - 1:
+                        if i < n - 1:
+                            name = prefix + "Boxes " + str(i + 1 - group_size) + " - " + str(i)
+                        else:
+                            if len(current_group) > 1:
+                                name = prefix + "Boxes " + str(i + 1  - len(current_group)) + " - " + str(i)
+                            else:
+                                name = prefix + "Box " + str(i)
+                        data = Model.BoundingBoxData(name, current_group)
+                        box_data.append(data)
+                        current_group = []
+            self._objects.bounding_box_data = box_data
+
         self._visualize("Open3D", width, height)
 
     def _visualize(self, title, width, height):
@@ -1377,6 +1490,10 @@ class Visualizer:
             self._3d.scene.show_geometry(name, True)
 
         def on_done_ui():
+            # Add bounding boxes here: bounding boxes belonging to the dataset
+            # will not be loaded until now.
+            self._update_bounding_boxes()
+
             self._update_datasource_combobox()
             self._update_shaders_combobox()
 

--- a/ml3d/vis/visualizer.py
+++ b/ml3d/vis/visualizer.py
@@ -18,6 +18,7 @@ class Model:
     bounding_box_prefix = "Bounding Boxes/"
 
     class BoundingBoxData:
+
         def __init__(self, name, boxes):
             self.name = name
             self.boxes = boxes
@@ -274,7 +275,8 @@ class DatasetModel(Model):
         data["points"] = data["point"]
 
         if 'bounding_boxes' in data:
-            self.bounding_box_data.append(Model.BoundingBoxData(name, data['bounding_boxes']))
+            self.bounding_box_data.append(
+                Model.BoundingBoxData(name, data['bounding_boxes']))
 
         self.create_point_cloud(data)
         size = self._calc_pointcloud_size(self._data[name], self.tclouds[name])
@@ -1093,7 +1095,8 @@ class Visualizer:
             # Don't run this more than once if we aren't consolidating,
             # because nothing will change.
             if len(self._objects.bounding_box_data) > 0:
-                if self._objects.bounding_box_data[0].name in self._name2treenode:
+                if self._objects.bounding_box_data[
+                        0].name in self._name2treenode:
                     return
 
             for bbox_data in self._objects.bounding_box_data:
@@ -1136,7 +1139,7 @@ class Visualizer:
         material = self._get_material()
         for name, tcloud in self._objects.tclouds.items():
             if not tcloud.is_empty() and self._3d.scene.has_geometry(name):
-                    self._3d.scene.modify_geometry_material(name, material)
+                self._3d.scene.modify_geometry_material(name, material)
         self._3d.force_redraw()
 
     def _update_datasource_combobox(self):
@@ -1421,9 +1424,13 @@ class Visualizer:
         self._consolidate_bounding_boxes = True
         self._init_dataset(dataset, split, indices)
         self._visualize("Open3D - " + dataset.name, width, height)
- 
-    def visualize(self, data, lut=None, bounding_boxes=None,
-                  width=1024, height=768):
+
+    def visualize(self,
+                  data,
+                  lut=None,
+                  bounding_boxes=None,
+                  width=1024,
+                  height=768):
         """Visualizes custom point cloud data
 
         Example:
@@ -1462,8 +1469,10 @@ class Visualizer:
             # many.
             group_size = int(math.floor(float(len(bounding_boxes)) / 100.0))
             if group_size < 2:
-                box_data = [Model.BoundingBoxData(prefix + str(bbox), [bbox])
-                            for bbox in bounding_boxes]
+                box_data = [
+                    Model.BoundingBoxData(prefix + str(bbox), [bbox])
+                    for bbox in bounding_boxes
+                ]
             else:
                 box_data = []
                 current_group = []
@@ -1472,10 +1481,12 @@ class Visualizer:
                     current_group.append(bounding_boxes[i])
                     if len(current_group) >= group_size or i == n - 1:
                         if i < n - 1:
-                            name = prefix + "Boxes " + str(i + 1 - group_size) + " - " + str(i)
+                            name = prefix + "Boxes " + str(
+                                i + 1 - group_size) + " - " + str(i)
                         else:
                             if len(current_group) > 1:
-                                name = prefix + "Boxes " + str(i + 1  - len(current_group)) + " - " + str(i)
+                                name = prefix + "Boxes " + str(
+                                    i + 1 - len(current_group)) + " - " + str(i)
                             else:
                                 name = prefix + "Box " + str(i)
                         data = Model.BoundingBoxData(name, current_group)


### PR DESCRIPTION
- Adds ml3d.vis.BoundingBox3D
- Visualizer.visualize() has an optional `bounding_boxes` argument, which takes an array of BoundingBox3D.
- Visualizer.visualize_dataset() looks for a `bounding_boxes` key in the dictionary returned by get_data().

Please see the following Python script for an example of usage. (Rename from .txt to .py, since Github does not accept .py files)
[boxes.txt](https://github.com/intel-isl/Open3D-ML/files/5537995/boxes.txt)
