### PR TITLE
Fix image link in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ pipeline.run_train()
 
 Below is an example of visualization using KITTI. The example shows the use of bounding boxes for the KITTI dataset.
 
-<img width="480" src="https://github.com/intel-isl/Open3D/docs/images/visualizer_BoundingBoxes.png">
+<img width="480" src="https://github.com/intel-isl/Open3D-ML/blob/master/docs/images/visualizer_BoundingBoxes.png?raw=true">
 
 
 For more examples see [`examples/`](https://github.com/intel-isl/Open3D-ML/tree/master/examples)


### PR DESCRIPTION
Fix link to Object detection image in readme. (merge to master)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d-ml/209)
<!-- Reviewable:end -->
