### PR TITLE
Add worker_init_fn in torch dataloader

### DIFF
--- a/ml3d/torch/dataloaders/concat_batcher.py
+++ b/ml3d/torch/dataloaders/concat_batcher.py
@@ -423,6 +423,11 @@ class PointPillarsBatch:
 
         for batch in batches:
             data = batch['data']
+            attr = batch['attr']
+            if 'test' not in attr['split'] and len(
+                    data['bboxes']
+            ) == 0:  # Skip training batch with no bounding box.
+                continue
             self.point.append(torch.tensor(data['point'], dtype=torch.float32))
             self.labels.append(
                 torch.tensor(data['labels'], dtype=torch.int64) if 'labels' in

--- a/ml3d/torch/pipelines/object_detection.py
+++ b/ml3d/torch/pipelines/object_detection.py
@@ -100,8 +100,8 @@ class ObjectDetection(BasePipeline):
             num_workers=cfg.get('num_workers', 4),
             pin_memory=cfg.get('pin_memory', True),
             collate_fn=batcher.collate_fn,
-            worker_init_fn=lambda x: np.random.seed(x + int(
-                torch.utils.data.get_worker_info().seed % 1000000)))
+            worker_init_fn=lambda x: np.random.seed(x + np.uint32(
+                torch.utils.data.get_worker_info().seed)))
 
         self.load_ckpt(model.cfg.ckpt_path)
 
@@ -153,8 +153,8 @@ class ObjectDetection(BasePipeline):
             num_workers=cfg.get('num_workers', 4),
             pin_memory=cfg.get('pin_memory', True),
             collate_fn=batcher.collate_fn,
-            worker_init_fn=lambda x: np.random.seed(x + int(
-                torch.utils.data.get_worker_info().seed % 1000000)))
+            worker_init_fn=lambda x: np.random.seed(x + np.uint32(
+                torch.utils.data.get_worker_info().seed)))
 
         log.info("Started validation")
 
@@ -256,8 +256,9 @@ class ObjectDetection(BasePipeline):
             num_workers=cfg.get('num_workers', 4),
             pin_memory=cfg.get('pin_memory', True),
             collate_fn=batcher.collate_fn,
-            worker_init_fn=lambda x: np.random.seed(x + int(
-                torch.utils.data.get_worker_info().seed % 1000000)))
+            worker_init_fn=lambda x: np.random.seed(x + np.uint32(
+                torch.utils.data.get_worker_info().seed))
+        )  # numpy expects np.uint32, whereas torch returns np.uint64.
 
         self.optimizer, self.scheduler = model.get_optimizer(cfg.optimizer)
 

--- a/ml3d/torch/pipelines/object_detection.py
+++ b/ml3d/torch/pipelines/object_detection.py
@@ -3,7 +3,6 @@ import logging
 from tqdm import tqdm
 import numpy as np
 import re
-import time
 
 from datetime import datetime
 
@@ -101,7 +100,8 @@ class ObjectDetection(BasePipeline):
             num_workers=cfg.get('num_workers', 4),
             pin_memory=cfg.get('pin_memory', True),
             collate_fn=batcher.collate_fn,
-            worker_init_fn=lambda x: np.random.seed(x + int(time.time())))
+            worker_init_fn=lambda x: np.random.seed(x + int(
+                torch.utils.data.get_worker_info().seed % 1000000)))
 
         self.load_ckpt(model.cfg.ckpt_path)
 
@@ -153,7 +153,8 @@ class ObjectDetection(BasePipeline):
             num_workers=cfg.get('num_workers', 4),
             pin_memory=cfg.get('pin_memory', True),
             collate_fn=batcher.collate_fn,
-            worker_init_fn=lambda x: np.random.seed(x + int(time.time())))
+            worker_init_fn=lambda x: np.random.seed(x + int(
+                torch.utils.data.get_worker_info().seed % 1000000)))
 
         log.info("Started validation")
 
@@ -255,7 +256,8 @@ class ObjectDetection(BasePipeline):
             num_workers=cfg.get('num_workers', 4),
             pin_memory=cfg.get('pin_memory', True),
             collate_fn=batcher.collate_fn,
-            worker_init_fn=lambda x: np.random.seed(x + int(time.time())))
+            worker_init_fn=lambda x: np.random.seed(x + int(
+                torch.utils.data.get_worker_info().seed % 1000000)))
 
         self.optimizer, self.scheduler = model.get_optimizer(cfg.optimizer)
 

--- a/ml3d/torch/pipelines/object_detection.py
+++ b/ml3d/torch/pipelines/object_detection.py
@@ -3,6 +3,7 @@ import logging
 from tqdm import tqdm
 import numpy as np
 import re
+import time
 
 from datetime import datetime
 
@@ -100,7 +101,7 @@ class ObjectDetection(BasePipeline):
             num_workers=cfg.get('num_workers', 4),
             pin_memory=cfg.get('pin_memory', True),
             collate_fn=batcher.collate_fn,
-        )
+            worker_init_fn=lambda x: np.random.seed(x + int(time.time())))
 
         self.load_ckpt(model.cfg.ckpt_path)
 
@@ -152,7 +153,7 @@ class ObjectDetection(BasePipeline):
             num_workers=cfg.get('num_workers', 4),
             pin_memory=cfg.get('pin_memory', True),
             collate_fn=batcher.collate_fn,
-        )
+            worker_init_fn=lambda x: np.random.seed(x + int(time.time())))
 
         log.info("Started validation")
 
@@ -254,7 +255,7 @@ class ObjectDetection(BasePipeline):
             num_workers=cfg.get('num_workers', 4),
             pin_memory=cfg.get('pin_memory', True),
             collate_fn=batcher.collate_fn,
-        )
+            worker_init_fn=lambda x: np.random.seed(x + int(time.time())))
 
         self.optimizer, self.scheduler = model.get_optimizer(cfg.optimizer)
 

--- a/ml3d/torch/pipelines/semantic_segmentation.py
+++ b/ml3d/torch/pipelines/semantic_segmentation.py
@@ -352,8 +352,9 @@ class SemanticSegmentation(BasePipeline):
             num_workers=cfg.get('num_workers', 4),
             pin_memory=cfg.get('pin_memory', True),
             collate_fn=self.batcher.collate_fn,
-            worker_init_fn=lambda x: np.random.seed(x + int(
-                torch.utils.data.get_worker_info().seed % 1000000)))
+            worker_init_fn=lambda x: np.random.seed(x + np.uint32(
+                torch.utils.data.get_worker_info().seed))
+        )  # numpy expects np.uint32, whereas torch returns np.uint64.
 
         valid_dataset = dataset.get_split('validation')
         valid_sampler = valid_dataset.sampler
@@ -371,8 +372,8 @@ class SemanticSegmentation(BasePipeline):
             num_workers=cfg.get('num_workers', 4),
             pin_memory=cfg.get('pin_memory', True),
             collate_fn=self.batcher.collate_fn,
-            worker_init_fn=lambda x: np.random.seed(x + int(
-                torch.utils.data.get_worker_info().seed % 1000000)))
+            worker_init_fn=lambda x: np.random.seed(x + np.uint32(
+                torch.utils.data.get_worker_info().seed)))
 
         self.optimizer, self.scheduler = model.get_optimizer(cfg)
 

--- a/ml3d/torch/pipelines/semantic_segmentation.py
+++ b/ml3d/torch/pipelines/semantic_segmentation.py
@@ -4,7 +4,6 @@ import numpy as np
 import logging
 import sys
 import warnings
-import time
 
 from datetime import datetime
 from tqdm import tqdm
@@ -353,7 +352,8 @@ class SemanticSegmentation(BasePipeline):
             num_workers=cfg.get('num_workers', 4),
             pin_memory=cfg.get('pin_memory', True),
             collate_fn=self.batcher.collate_fn,
-            worker_init_fn=lambda x: np.random.seed(x + int(time.time())))
+            worker_init_fn=lambda x: np.random.seed(x + int(
+                torch.utils.data.get_worker_info().seed % 1000000)))
 
         valid_dataset = dataset.get_split('validation')
         valid_sampler = valid_dataset.sampler
@@ -371,7 +371,8 @@ class SemanticSegmentation(BasePipeline):
             num_workers=cfg.get('num_workers', 4),
             pin_memory=cfg.get('pin_memory', True),
             collate_fn=self.batcher.collate_fn,
-            worker_init_fn=lambda x: np.random.seed(x + int(time.time())))
+            worker_init_fn=lambda x: np.random.seed(x + int(
+                torch.utils.data.get_worker_info().seed % 1000000)))
 
         self.optimizer, self.scheduler = model.get_optimizer(cfg)
 

--- a/ml3d/torch/pipelines/semantic_segmentation.py
+++ b/ml3d/torch/pipelines/semantic_segmentation.py
@@ -4,6 +4,7 @@ import numpy as np
 import logging
 import sys
 import warnings
+import time
 
 from datetime import datetime
 from tqdm import tqdm
@@ -345,12 +346,14 @@ class SemanticSegmentation(BasePipeline):
                                       use_cache=dataset.cfg.use_cache,
                                       steps_per_epoch=dataset.cfg.get(
                                           'steps_per_epoch_train', None))
-        train_loader = DataLoader(train_split,
-                                  batch_size=cfg.batch_size,
-                                  sampler=get_sampler(train_sampler),
-                                  num_workers=cfg.get('num_workers', 4),
-                                  pin_memory=cfg.get('pin_memory', True),
-                                  collate_fn=self.batcher.collate_fn)
+        train_loader = DataLoader(
+            train_split,
+            batch_size=cfg.batch_size,
+            sampler=get_sampler(train_sampler),
+            num_workers=cfg.get('num_workers', 4),
+            pin_memory=cfg.get('pin_memory', True),
+            collate_fn=self.batcher.collate_fn,
+            worker_init_fn=lambda x: np.random.seed(x + int(time.time())))
 
         valid_dataset = dataset.get_split('validation')
         valid_sampler = valid_dataset.sampler
@@ -361,12 +364,14 @@ class SemanticSegmentation(BasePipeline):
                                       use_cache=dataset.cfg.use_cache,
                                       steps_per_epoch=dataset.cfg.get(
                                           'steps_per_epoch_valid', None))
-        valid_loader = DataLoader(valid_split,
-                                  batch_size=cfg.val_batch_size,
-                                  sampler=get_sampler(valid_sampler),
-                                  num_workers=cfg.get('num_workers', 4),
-                                  pin_memory=cfg.get('pin_memory', True),
-                                  collate_fn=self.batcher.collate_fn)
+        valid_loader = DataLoader(
+            valid_split,
+            batch_size=cfg.val_batch_size,
+            sampler=get_sampler(valid_sampler),
+            num_workers=cfg.get('num_workers', 4),
+            pin_memory=cfg.get('pin_memory', True),
+            collate_fn=self.batcher.collate_fn,
+            worker_init_fn=lambda x: np.random.seed(x + int(time.time())))
 
         self.optimizer, self.scheduler = model.get_optimizer(cfg)
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -167,7 +167,7 @@ def test_pointpillars_torch():
     }
     data = net.preprocess(data, {'split': 'test'})
     data = net.transform(data, {'split': 'test'})
-    data = batcher.collate_fn([{'data': data}])
+    data = batcher.collate_fn([{'data': data, 'attr': {'split': 'test'}}])
 
     net.eval()
     with torch.no_grad():


### PR DESCRIPTION
1.) Added `worker_init_fn` in torch dataloader to fix randomization issue.
2.) Skip batch(training) element with no bounding box.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d-ml/254)
<!-- Reviewable:end -->
