### PR TITLE
Fix required by Open3D #3298

### DIFF
--- a/ml3d/vis/visualizer.py
+++ b/ml3d/vis/visualizer.py
@@ -1279,9 +1279,9 @@ class Visualizer:
 
         self._update_geometry_colors()
 
-    def _on_layout(self, theme):
+    def _on_layout(self, context):
         frame = self.window.content_rect
-        em = theme.font_size
+        em = context.theme.font_size
         panel_width = 20 * em
         panel_rect = gui.Rect(frame.get_right() - panel_width, frame.y,
                               panel_width, frame.height - frame.y)


### PR DESCRIPTION
The following scripts can be used to test:
Interactive
```
#!/usr/bin/env python
import numpy as np
import open3d as o3d
import open3d.visualization.gui as gui

RGB_FILE = "/home/prewettg/open3d-dev/examples/test_data/RGBD/color/00004.jpg"
DEPTH_FILE = "/home/prewettg/open3d-dev/examples/test_data/RGBD/depth/00004.png"
POSE = np.array([[0.999853,     -0.00039972, 0.0171503,   2.00124],
                 [-0.000434556,  0.998818,   0.0486137,   1.90487],
                 [-0.0171495,   -0.048614,   0.998671,   -0.305411],
                 [ 0,            0,          0,           1]])

def main():
    volume = o3d.pipelines.integration.ScalableTSDFVolume(
                voxel_length=4.0/512.0,
                sdf_trunc=0.04,
                color_type=o3d.pipelines.integration.TSDFVolumeColorType.RGB8)
    color = o3d.io.read_image(RGB_FILE)
    depth = o3d.io.read_image(DEPTH_FILE)
    rgbd = o3d.geometry.RGBDImage.create_from_color_and_depth(
        color, depth, depth_trunc=4.0, convert_rgb_to_intensity=False)
    intrinsics = o3d.camera.PinholeCameraIntrinsic(
        o3d.camera.PinholeCameraIntrinsicParameters.PrimeSenseDefault)
    extrinsic = np.linalg.inv(POSE)
    volume.integrate(rgbd, intrinsics, extrinsic)

    cloud = volume.extract_point_cloud()

    app = gui.Application.instance
    app.initialize()
    vis = o3d.visualization.O3DVisualizer("Instrincs", 640, 480)
    vis.add_geometry("points", cloud)
    vis.setup_camera(intrinsics, extrinsic)
    app.add_window(vis)
    app.run()

if __name__ == "__main__":
    main()
```
Render to image
```
#!/usr/bin/env python
import numpy as np
import open3d as o3d
import open3d.visualization.rendering as rendering

OUT_FILE = "/tmp/pinhole.png"

RGB_FILE = "/home/prewettg/open3d-dev/examples/test_data/RGBD/color/00004.jpg"
DEPTH_FILE = "/home/prewettg/open3d-dev/examples/test_data/RGBD/depth/00004.png"
POSE = np.array([[0.999853,     -0.00039972, 0.0171503,   2.00124],
                 [-0.000434556,  0.998818,   0.0486137,   1.90487],
                 [-0.0171495,   -0.048614,   0.998671,   -0.305411],
                 [ 0,            0,          0,           1]])

def main():
    volume = o3d.pipelines.integration.ScalableTSDFVolume(
                voxel_length=4.0/512.0,
                sdf_trunc=0.04,
                color_type=o3d.pipelines.integration.TSDFVolumeColorType.RGB8)
    color = o3d.io.read_image(RGB_FILE)
    depth = o3d.io.read_image(DEPTH_FILE)
    rgbd = o3d.geometry.RGBDImage.create_from_color_and_depth(
        color, depth, depth_trunc=4.0, convert_rgb_to_intensity=False)
    intrinsics = o3d.camera.PinholeCameraIntrinsic(
        o3d.camera.PinholeCameraIntrinsicParameters.PrimeSenseDefault)
    extrinsic = np.linalg.inv(POSE)
    volume.integrate(rgbd, intrinsics, extrinsic)

    cloud = volume.extract_point_cloud()

    render = rendering.OffscreenRenderer(640, 480)
    unlit = rendering.Material()
    unlit.shader = "defaultUnlit"
    unlit.point_size = 2
    render.scene.add_geometry("cloud", cloud, unlit)
    render.setup_camera(intrinsics, extrinsic)
    img = render.render_to_image()
    o3d.io.write_image(OUT_FILE, img, 9)
    print("Write", OUT_FILE)

if __name__ == "__main__":
    main()
```
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/intel-isl/open3d-ml/262)
<!-- Reviewable:end -->
